### PR TITLE
feat: add external articles feed + Studio importer

### DIFF
--- a/apps/simeongriggs.dev/app/components/HomeCommunity.tsx
+++ b/apps/simeongriggs.dev/app/components/HomeCommunity.tsx
@@ -2,18 +2,18 @@ import {LinkIcon} from '@heroicons/react/24/solid'
 import {Subheading} from '@repo/frontend'
 
 import Published from '~/components/Published'
-import type {ExchangeStub} from '~/types/stubs'
+import type {ExternalArticleStub} from '~/types/stubs'
 
-export default function HomeCommunity(props: ExchangeStub) {
-  const {slug, title, published, updated, summary} = props
+export default function HomeCommunity(props: ExternalArticleStub) {
+  const {title, published, updated, summary, url, source} = props
 
   return (
     <article className="-mx-4 grid grid-cols-1 gap-y-4 border-gray-100 px-4 md:mx-0 md:border-l-4 dark:border-blue-800">
-      {slug?.current ? (
+      {url ? (
         <h3 className="text-2xl font-black tracking-tighter text-blue-500 hover:text-white md:text-2xl md:leading-none">
           <LinkIcon className="float-right h-auto w-5" />
           <a
-            href={`https://www.sanity.io/guides/${slug.current}`}
+            href={url}
             className="block hover:bg-[#f03e2f] hover:text-white"
             target="_blank"
             rel="noopener noreferrer"
@@ -28,7 +28,13 @@ export default function HomeCommunity(props: ExchangeStub) {
       {published ? (
         <div className="flex justify-between">
           <Published published={published} updated={updated ?? ``} />
-          <Subheading>Posted on Sanity.io Exchange</Subheading>
+          <Subheading>
+            {source === 'sanity_guides'
+              ? 'Posted on Sanity.io'
+              : source === 'sanity_learn'
+                ? 'Published on Sanity Learn'
+                : 'Published on PlanetScale'}
+          </Subheading>
         </div>
       ) : null}
 

--- a/apps/simeongriggs.dev/app/components/Published.tsx
+++ b/apps/simeongriggs.dev/app/components/Published.tsx
@@ -17,10 +17,12 @@ export default function Published({
   location,
   published,
 }: PublishedProps) {
+  const showUpdated = Boolean(updated && dateDisplay(updated) !== dateDisplay(published))
+
   return (
     <Subheading>
       <span className="flex flex-col md:flex-row md:items-center">
-        {updated ? (
+        {showUpdated ? (
           <span>
             <time dateTime={published}>{dateDisplay(published)}</time>
             {` `}•{` `}

--- a/apps/simeongriggs.dev/app/components/Timeline.tsx
+++ b/apps/simeongriggs.dev/app/components/Timeline.tsx
@@ -1,8 +1,7 @@
 import type {
   ArticleStub,
   CombinedStubs,
-  ExchangeStub,
-  LearnStub,
+  ExternalArticleStub,
   TalkStub,
   YouTubeVideoStub,
 } from '~/types/stubs'
@@ -45,14 +44,12 @@ export function Timeline({articles}: TimelineProps) {
                 switch (article._type) {
                   case 'article':
                     return <BlogPost article={article} />
-                  case 'contribution.guide':
-                    return <Sanity article={article} />
+                  case 'externalArticle':
+                    return <External article={article} />
                   case 'talk':
                     return <Talk article={article} />
                   case 'youTubeVideo':
                     return <Video article={article} />
-                  case 'course':
-                    return <Sanity article={article} />
                   default:
                     return null
                 }
@@ -182,24 +179,32 @@ function Talk({article}: {article: TalkStub}) {
   return <Video article={videoProps} pillText="Talk" />
 }
 
-function Sanity({article}: {article: ExchangeStub | LearnStub}) {
+function External({article}: {article: ExternalArticleStub}) {
+  const href = article.url ?? undefined
+  const pill =
+    article.source === 'planetscale'
+      ? 'PlanetScale'
+      : article.source === 'sanity_guides'
+        ? 'Sanity Guide'
+        : 'Sanity Course'
+
   return (
     <div className="flex w-full justify-between">
       <div className="flex w-full flex-col gap-4 py-0.5 text-lg/8 text-gray-500">
         <h2>
-          <a
-            className="font-medium text-[#f03e2f] hover:text-red-700"
-            href={
-              article._type === 'contribution.guide'
-                ? `https://www.sanity.io/guides/${article.slug.current}`
-                : `https://www.sanity.io/learn/course/${article.slug.current}`
-            }
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {article.title} &rarr;
-            <span className="absolute inset-0"></span>
-          </a>
+          {href ? (
+            <a
+              className="font-medium text-blue-500 hover:text-blue-700 dark:text-blue-200 dark:hover:text-blue-100"
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {article.title} &rarr;
+              <span className="absolute inset-0"></span>
+            </a>
+          ) : (
+            <span className="font-medium">{article.title}</span>
+          )}
         </h2>
         <Summary>{article.summary}</Summary>
 
@@ -207,17 +212,13 @@ function Sanity({article}: {article: ExchangeStub | LearnStub}) {
           {article.published ? (
             <Published
               updated={
-                article._type === 'contribution.guide' && article.updated
-                  ? article.updated
-                  : undefined
+                article.updated ? article.updated : undefined
               }
               published={article.published}
             />
           ) : null}
 
-          <Pill>
-            {article._type === 'contribution.guide' ? 'Guide' : 'Course'}
-          </Pill>
+          <Pill>{pill}</Pill>
         </div>
       </div>
     </div>
@@ -254,10 +255,9 @@ type TabsProps = {
 const TAB_TITLES: Record<string, string> = {
   all: 'All',
   article: 'Blogs',
-  'contribution.guide': 'Guides',
+  externalArticle: 'External',
   talk: 'Talks',
   youTubeVideo: 'YouTube',
-  course: 'Courses',
 }
 
 function Tabs({tabs, current, onChange}: TabsProps) {

--- a/apps/simeongriggs.dev/app/routes/_website._index.tsx
+++ b/apps/simeongriggs.dev/app/routes/_website._index.tsx
@@ -4,20 +4,13 @@ import {useLoaderData} from 'react-router'
 import {Timeline} from '~/components/Timeline'
 import {useRootLoaderData} from '~/hooks/useRootLoaderData'
 import {sortArticles} from '~/lib/sortArticles'
-import {adminClient, exchangeClient} from '~/sanity/client.server'
 import {fixInitialType} from '~/sanity/fixInitialType'
 import {loadQuery} from '~/sanity/loader.server'
 import {loadQueryOptions} from '~/sanity/loadQueryOptions'
-import {
-  EXCHANGE_QUERY,
-  HOME_QUERY,
-  LEARN_QUERY,
-  exchangeParams,
-  learnParams,
-} from '~/sanity/queries'
+import {HOME_QUERY} from '~/sanity/queries'
 import styles from '@repo/tailwind/app.css?url'
-import type {ArticleStub} from '~/types/stubs'
-import {combinedStubsZ, exchangeStubsZ, learnStubsZ} from '~/types/stubs'
+import type {CombinedStubs} from '~/types/stubs'
+import {combinedStubsZ} from '~/types/stubs'
 import {components, Heading} from '@repo/frontend'
 import {PortableText} from '@portabletext/react'
 import type {Route} from './+types/_website._index'
@@ -37,29 +30,18 @@ export const loader = async ({request}: Route.LoaderArgs) => {
   const query = HOME_QUERY
   const params = {}
 
-  const [initial, exchangeArticles, learnArticles] = await Promise.all([
-    loadQuery(query, params, options).then((result) => ({
-      ...result,
-      data: combinedStubsZ.parse(result.data),
-    })),
-    exchangeClient
-      .fetch(EXCHANGE_QUERY, exchangeParams)
-      .then((result) => exchangeStubsZ.parse(result)),
-    adminClient
-      .fetch(LEARN_QUERY, learnParams)
-      .then((result) => learnStubsZ.parse(result)),
-  ])
+  const initial = await loadQuery(query, params, options).then((result) => ({
+    ...result,
+    data: combinedStubsZ.parse(result.data),
+  }))
 
-  return {initial, query, params, exchangeArticles, learnArticles, preview}
+  return {initial, query, params, preview}
 }
 
 export default function Index() {
-  const {initial, query, params, exchangeArticles, learnArticles} =
-    useLoaderData<typeof loader>()
-  const {data} = useQuery<ArticleStub[]>(query, params, fixInitialType(initial))
-  const articles = data
-    ? sortArticles([...data, ...exchangeArticles, ...learnArticles])
-    : []
+  const {initial, query, params} = useLoaderData<typeof loader>()
+  const {data} = useQuery<CombinedStubs>(query, params, fixInitialType(initial))
+  const articles = data ? sortArticles(data) : []
 
   const rootLoader = useRootLoaderData()
   const siteMeta = rootLoader?.initial?.data

--- a/apps/simeongriggs.dev/app/sanity/client.ts
+++ b/apps/simeongriggs.dev/app/sanity/client.ts
@@ -6,6 +6,6 @@ export const client = createClient({
   projectId,
   dataset,
   apiVersion,
-  useCdn: true,
+  useCdn: process.env.NODE_ENV === 'production',
   perspective: 'published',
 })

--- a/apps/simeongriggs.dev/app/sanity/queries.tsx
+++ b/apps/simeongriggs.dev/app/sanity/queries.tsx
@@ -100,7 +100,7 @@ export const TALK_PROJECTION = groq`
 export const TALK_QUERY = groq`*[_type == "talk" && slug.current == $slug]{ ${TALK_PROJECTION} }`
 
 export const HOME_QUERY = groq`
-  *[_type in ["article", "talk", "youTubeVideo"] && unlisted != true]|order(published desc){
+  *[_type in ["article", "externalArticle", "talk", "youTubeVideo"] && unlisted != true]|order(published desc){
     _id,
     _type,
     _updatedAt,
@@ -108,6 +108,13 @@ export const HOME_QUERY = groq`
     slug,
     image { ${SANITY_IMAGE_OBJECT_STUB} },
     _type == "article" => {
+      published,
+      updated,
+      summary
+    },
+    _type == "externalArticle" => {
+      source,
+      url,
       published,
       updated,
       summary

--- a/apps/simeongriggs.dev/app/types/stubs.ts
+++ b/apps/simeongriggs.dev/app/types/stubs.ts
@@ -34,34 +34,21 @@ export const talkStubZ = z.object({
 
 export type TalkStub = z.infer<typeof talkStubZ>
 
-// Exchange posts, from Sanity
-export const exchangeStubZ = z.object({
+export const externalArticleStubZ = z.object({
   _id: z.string(),
-  _type: z.literal('contribution.guide'),
+  _type: z.literal('externalArticle'),
   title: z.string().nullable(),
-  slug: slugZ,
+  summary: z.string().nullable(),
   published: z.string().nullable(),
   updated: z.string().nullable(),
-  summary: z.string().nullable(),
+  image: sanityImageObjectExtendedZ.nullable(),
+  source: z.enum(['planetscale', 'sanity_guides', 'sanity_learn']),
+  url: z.string().nullable(),
 })
 
-export type ExchangeStub = z.infer<typeof exchangeStubZ>
+export type ExternalArticleStub = z.infer<typeof externalArticleStubZ>
 
-export const exchangeStubsZ = z.array(exchangeStubZ)
-
-// Learn courses, from Sanity
-export const learnStubZ = z.object({
-  _id: z.string(),
-  _type: z.literal('course'),
-  title: z.string().nullable(),
-  slug: slugZ,
-  published: z.string().nullable(),
-  summary: z.string().nullable(),
-})
-
-export type LearnStub = z.infer<typeof learnStubZ>
-
-export const learnStubsZ = z.array(learnStubZ)
+export const externalArticleStubsZ = z.array(externalArticleStubZ)
 
 // YouTube Video Documents, from this blog
 export const youTubeVideoStubZ = z.object({
@@ -83,8 +70,7 @@ export const combinedStubsZ = z.array(
   z.discriminatedUnion('_type', [
     articleStubZ,
     talkStubZ,
-    exchangeStubZ,
-    learnStubZ,
+    externalArticleStubZ,
     youTubeVideoStubZ,
   ]),
 )

--- a/packages/sanity/src/index.ts
+++ b/packages/sanity/src/index.ts
@@ -14,6 +14,7 @@ import {youTubeDocuments} from 'sanity-plugin-youtube-documents'
 import {resolve} from './presentation/resolve'
 import {schemaTypes} from './schema'
 import {defaultDocumentNode, structure} from './structure'
+import {externalArticlesTool} from './tools/externalArticlesTool'
 
 export default defineConfig({
   name: 'simeonGriggs',
@@ -46,8 +47,8 @@ export default defineConfig({
   schema: {
     types: schemaTypes,
   },
-  tools: (prev, context) =>
-    prev.filter((tool) => {
+  tools: (prev: any[], context: any) =>
+    [...prev, externalArticlesTool].filter((tool) => {
       if (tool.name === 'schedules') {
         return false
       } else if (!context.currentUser && tool.name === 'presentation') {

--- a/packages/sanity/src/schema/documents/externalArticleType.tsx
+++ b/packages/sanity/src/schema/documents/externalArticleType.tsx
@@ -1,0 +1,152 @@
+import type {Rule} from 'sanity'
+import {defineField, defineType} from 'sanity'
+
+import HeroIcon from '../../components/HeroIcon'
+
+const SOURCE_VALUES = ['planetscale', 'sanity_guides', 'sanity_learn'] as const
+
+type ExternalArticleSource = (typeof SOURCE_VALUES)[number]
+
+type UnlistedDoc = {unlisted?: boolean; source?: ExternalArticleSource}
+type HiddenProps = {document?: UnlistedDoc}
+
+function validateUrlForSource(
+  url: string | undefined,
+  source: ExternalArticleSource | undefined,
+) {
+  if (!url || !source) return true
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return 'URL must be valid'
+  }
+
+  if (parsed.protocol !== 'https:') return 'URL must be https'
+
+  const host = parsed.hostname
+  const path = parsed.pathname
+
+  if (source === 'planetscale') {
+    if (host !== 'planetscale.com') return 'PlanetScale URLs must be on planetscale.com'
+    if (!path.startsWith('/blog/')) return 'PlanetScale URLs must start with /blog/'
+  }
+
+  if (source === 'sanity_guides') {
+    if (host !== 'www.sanity.io') return 'Sanity guide URLs must be on www.sanity.io'
+    if (!path.startsWith('/guides/')) return 'Sanity guide URLs must start with /guides/'
+  }
+
+  if (source === 'sanity_learn') {
+    if (host !== 'www.sanity.io') return 'Sanity learn URLs must be on www.sanity.io'
+    if (!path.startsWith('/learn/course/'))
+      return 'Sanity learn URLs must start with /learn/course/'
+  }
+
+  return true
+}
+
+export const externalArticleType = defineType({
+  name: 'externalArticle',
+  title: 'External Article',
+  icon: () => <HeroIcon icon="link" />,
+  type: 'document',
+  orderings: [
+    {
+      title: 'Published',
+      name: 'publishedDesc',
+      by: [{field: 'published', direction: 'desc'}],
+    },
+  ],
+  fieldsets: [{name: 'dates', title: 'Dates', options: {columns: 2}}],
+  fields: [
+    defineField({
+      name: 'unlisted',
+      type: 'boolean',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'source',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'PlanetScale', value: 'planetscale'},
+          {title: 'Sanity Guides', value: 'sanity_guides'},
+          {title: 'Sanity Learn', value: 'sanity_learn'},
+        ],
+      },
+      validation: (rule: Rule) => rule.required(),
+    }),
+    defineField({
+      name: 'title',
+      type: 'string',
+      validation: (rule: Rule) => rule.required(),
+    }),
+    defineField({
+      name: 'url',
+      title: 'URL',
+      type: 'url',
+      validation: (rule: Rule) =>
+        rule
+          .required()
+          .uri({scheme: ['https']})
+          .custom((value: unknown, {document}: {document?: UnlistedDoc}) =>
+            validateUrlForSource(
+              typeof value === 'string' ? value : undefined,
+              document?.source,
+            ),
+          ),
+    }),
+    defineField({
+      name: 'published',
+      type: 'date',
+      fieldset: 'dates',
+      hidden: (props: HiddenProps) => Boolean(props?.document?.unlisted),
+      validation: (rule: Rule) =>
+        rule.custom((value: unknown, {document}: {document?: UnlistedDoc}) => {
+          if (document?.unlisted) return true
+          return typeof value === 'string' && value ? true : 'Published date is required'
+        }),
+    }),
+    defineField({
+      name: 'updated',
+      type: 'date',
+      fieldset: 'dates',
+      hidden: (props: HiddenProps) => Boolean(props?.document?.unlisted),
+    }),
+    defineField({
+      name: 'summary',
+      type: 'text',
+      rows: 2,
+      hidden: (props: HiddenProps) => Boolean(props?.document?.unlisted),
+      validation: (rule: Rule) =>
+        rule.custom((value: unknown, {document}: {document?: UnlistedDoc}) => {
+          if (document?.unlisted) return true
+          return typeof value === 'string' && value ? true : 'Summary is required'
+        }),
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      source: 'source',
+      url: 'url',
+    },
+    prepare({
+      title,
+      source,
+      url,
+    }: {
+      title?: string
+      source?: string
+      url?: string
+    }) {
+      return {
+        title,
+        subtitle: [source, url].filter(Boolean).join(' • '),
+      }
+    },
+  },
+})
+

--- a/packages/sanity/src/schema/index.ts
+++ b/packages/sanity/src/schema/index.ts
@@ -11,6 +11,7 @@ import {buttonType} from './objects/buttonType'
 import {seoType} from './objects/seoType'
 import {videoType} from './objects/videoType'
 import {playbookType} from './documents/playbookType'
+import {externalArticleType} from './documents/externalArticleType'
 
 export const schemaTypes = [
   // documents
@@ -19,6 +20,7 @@ export const schemaTypes = [
   commentType,
   tailwindType,
   talkType,
+  externalArticleType,
   playbookType,
   // objects
   seoType,

--- a/packages/sanity/src/structure/index.ts
+++ b/packages/sanity/src/structure/index.ts
@@ -10,6 +10,7 @@ import HeroIcon from '../components/HeroIcon'
 export const structure: StructureResolver = (S, context) => {
   const items = [
     S.documentTypeListItem('article').title('Articles'),
+    S.documentTypeListItem('externalArticle').title('External Articles'),
     S.documentTypeListItem('talk').title('Talks'),
     S.documentTypeListItem('youTubeVideo')
       .title('Videos')

--- a/packages/sanity/src/tools/externalArticlesTool.tsx
+++ b/packages/sanity/src/tools/externalArticlesTool.tsx
@@ -1,0 +1,456 @@
+import {useClient} from 'sanity'
+import {Box, Button, Card, Container, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+import {RefreshIcon} from '@sanity/icons'
+
+type Source = 'planetscale' | 'sanity_guides' | 'sanity_learn'
+
+type ExternalArticleDoc = {
+  _id?: string
+  _type: 'externalArticle'
+  unlisted?: boolean
+  source: Source
+  title: string
+  url: string
+  summary?: string
+  published?: string
+  updated?: string
+}
+
+function stripHtml(input: string) {
+  return input
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function dateOnly(isoLike: string | undefined) {
+  if (!isoLike) return undefined
+  // Atom is ISO; Sanity dates may be ISO too. We store a `date` field (YYYY-MM-DD).
+  const d = new Date(isoLike)
+  if (Number.isNaN(d.getTime())) return undefined
+  return d.toISOString().slice(0, 10)
+}
+
+function updatedIfAfter(published: string | undefined, updated: string | undefined) {
+  if (!published || !updated) return undefined
+  const p = new Date(published)
+  const u = new Date(updated)
+  if (Number.isNaN(p.getTime()) || Number.isNaN(u.getTime())) return undefined
+  return u.getTime() > p.getTime() ? updated : undefined
+}
+
+async function getExistingIdsByUrl(
+  client: ReturnType<typeof useClient>,
+  source: Source,
+  urls: string[],
+) {
+  if (urls.length === 0) return new Map<string, string>()
+
+  const result = await client.fetch<{_id: string; url: string}[]>(
+    `*[_type == "externalArticle" && source == $source && url in $urls]{
+      _id,
+      url
+    }`,
+    {source, urls},
+  )
+
+  return new Map(result.map((d) => [d.url, d._id]))
+}
+
+async function getExistingDocsByUrl(
+  client: ReturnType<typeof useClient>,
+  source: Source,
+  urls: string[],
+) {
+  if (urls.length === 0) return []
+
+  return await client.fetch<{_id: string; url: string; _updatedAt: string}[]>(
+    `*[_type == "externalArticle" && source == $source && url in $urls]{
+      _id,
+      url,
+      _updatedAt
+    }`,
+    {source, urls},
+  )
+}
+
+function pickCanonicalIds(existing: {_id: string; url: string; _updatedAt: string}[]) {
+  const byUrl = new Map<string, {_id: string; _updatedAt: string}>()
+  const duplicates: string[] = []
+
+  for (const doc of existing) {
+    const current = byUrl.get(doc.url)
+    if (!current) {
+      byUrl.set(doc.url, {_id: doc._id, _updatedAt: doc._updatedAt})
+      continue
+    }
+
+    // Keep the most recently updated doc as canonical; delete the rest
+    const keepThis = new Date(doc._updatedAt).getTime() > new Date(current._updatedAt).getTime()
+    if (keepThis) {
+      duplicates.push(current._id)
+      byUrl.set(doc.url, {_id: doc._id, _updatedAt: doc._updatedAt})
+    } else {
+      duplicates.push(doc._id)
+    }
+  }
+
+  const canonical = new Map(Array.from(byUrl.entries()).map(([url, v]) => [url, v._id]))
+  return {canonical, duplicates}
+}
+
+async function fetchSanityQuery<T>(
+  projectId: string,
+  dataset: string,
+  query: string,
+) {
+  const url = new URL(`https://${projectId}.api.sanity.io/v2021-10-21/data/query/${dataset}`)
+  url.searchParams.set('query', query)
+  const res = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {'content-type': 'application/json'},
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Sanity query failed (${res.status}): ${text.slice(0, 400)}`)
+  }
+  const json = (await res.json()) as {result: T}
+  return json.result
+}
+
+async function fetchPlanetScaleFeed(authorName: string) {
+  const res = await fetch('https://planetscale.com/blog/feed.atom')
+  if (!res.ok) throw new Error(`PlanetScale feed failed (${res.status})`)
+  const xml = await res.text()
+  const doc = new DOMParser().parseFromString(xml, 'application/xml')
+  const entries = Array.from(doc.querySelectorAll('feed > entry'))
+
+  return entries
+    .map((entry) => {
+      const title = entry.querySelector('title')?.textContent?.trim() || ''
+      const url = entry.querySelector('link')?.getAttribute('href')?.trim() || ''
+      const published = entry.querySelector('published')?.textContent?.trim()
+      const updated = entry.querySelector('updated')?.textContent?.trim()
+      const summaryHtml = entry.querySelector('summary')?.textContent || ''
+      const author = entry.querySelector('author > name')?.textContent?.trim() || ''
+
+      return {
+        title,
+        url,
+        published: dateOnly(published),
+        updated: dateOnly(updated),
+        summary: stripHtml(summaryHtml),
+        author,
+      }
+    })
+    .filter((e) => e.title && e.url)
+    .filter((e) => (authorName ? e.author === authorName : true))
+}
+
+type ExchangeGuide = {
+  _id: string
+  title: string | null
+  slug: {current: string | null} | null
+  published: string | null
+  updated: string | null
+  summary: string | null
+}
+
+type LearnCourse = {
+  _id: string
+  title: string | null
+  slug: {current: string | null} | null
+  published: string | null
+  summary: string | null
+}
+
+function ExternalArticlesTool() {
+  const client = useClient({apiVersion: '2023-10-01'})
+  const [busy, setBusy] = useState<null | Source | 'all'>(null)
+  const [log, setLog] = useState<string[]>([])
+
+  const authorName = 'Simeon Griggs'
+  const userIds = useMemo(
+    () => ({
+      exchange: `e-cfe6c944570e1d29a8a0a8722108c4af`,
+      learn: `ee20547b-3a51-4515-b4d4-dd7461928291`,
+    }),
+    [],
+  )
+
+  const writeDocs = useCallback(
+    async (docs: ExternalArticleDoc[], opts?: {deleteIds?: string[]}) => {
+      const tx = client.transaction()
+      for (const id of opts?.deleteIds ?? []) tx.delete(id)
+      for (const doc of docs) {
+        if (doc._id) {
+          const {_id, ...rest} = doc
+          tx.patch(_id, (p) => p.set(rest))
+        } else {
+          tx.create(doc)
+        }
+      }
+      await tx.commit({autoGenerateArrayKeys: true})
+      return docs.length
+    },
+    [client],
+  )
+
+  const syncPlanetScale = useCallback(async (force?: boolean) => {
+    const feedEntries = await fetchPlanetScaleFeed(authorName)
+    const urls = feedEntries.map((e) => e.url)
+    const existing = force
+      ? pickCanonicalIds(await getExistingDocsByUrl(client, 'planetscale', urls))
+      : {canonical: await getExistingIdsByUrl(client, 'planetscale', urls), duplicates: []}
+    const docs: ExternalArticleDoc[] = []
+
+    for (const entry of feedEntries) {
+      const _id = existing.canonical.get(entry.url)
+      const updated = updatedIfAfter(entry.published, entry.updated)
+      docs.push({
+        _id,
+        _type: 'externalArticle',
+        unlisted: false,
+        source: 'planetscale',
+        title: entry.title,
+        url: entry.url,
+        summary: entry.summary,
+        published: entry.published,
+        updated,
+      })
+    }
+
+    return await writeDocs(docs, {deleteIds: existing.duplicates})
+  }, [authorName, client, writeDocs])
+
+  const syncSanityGuides = useCallback(async (force?: boolean) => {
+    const query = `*[
+      _type == "contribution.guide"
+      && defined(slug.current)
+      && hidden != true
+      && "${userIds.exchange}" in authors[]._ref
+    ]|order(publishedAt desc) {
+      _id,
+      title,
+      slug,
+      "published": publishedAt,
+      "updated": _updatedAt,
+      "summary": description
+    }`
+
+    const guides = await fetchSanityQuery<ExchangeGuide[]>(
+      '81pocpw8',
+      'production',
+      query,
+    )
+
+    const urls = guides
+      .map((g) => g.slug?.current)
+      .filter(Boolean)
+      .map((slug) => `https://www.sanity.io/guides/${slug}`)
+    const existing = force
+      ? pickCanonicalIds(await getExistingDocsByUrl(client, 'sanity_guides', urls))
+      : {canonical: await getExistingIdsByUrl(client, 'sanity_guides', urls), duplicates: []}
+
+    const docs: ExternalArticleDoc[] = []
+    for (const g of guides) {
+      const slug = g.slug?.current
+      const url = slug ? `https://www.sanity.io/guides/${slug}` : null
+      if (!g.title || !url) continue
+      const _id = existing.canonical.get(url)
+      docs.push({
+        _id,
+        _type: 'externalArticle',
+        unlisted: false,
+        source: 'sanity_guides',
+        title: g.title,
+        url,
+        summary: g.summary ?? undefined,
+        published: dateOnly(g.published ?? undefined),
+        updated: dateOnly(g.updated ?? undefined),
+      })
+    }
+
+    return await writeDocs(docs, {deleteIds: existing.duplicates})
+  }, [client, userIds.exchange, writeDocs])
+
+  const syncSanityLearn = useCallback(async (force?: boolean) => {
+    const query = `*[_type == "course" && "${userIds.learn}" in authors[]._ref]{
+      _id,
+      title,
+      slug,
+      "summary": description,
+      "published": _createdAt
+    }`
+
+    const courses = await fetchSanityQuery<LearnCourse[]>(
+      '3do82whm',
+      'next',
+      query,
+    )
+
+    const urls = courses
+      .map((c) => c.slug?.current)
+      .filter(Boolean)
+      .map((slug) => `https://www.sanity.io/learn/course/${slug}`)
+    const existing = force
+      ? pickCanonicalIds(await getExistingDocsByUrl(client, 'sanity_learn', urls))
+      : {canonical: await getExistingIdsByUrl(client, 'sanity_learn', urls), duplicates: []}
+
+    const docs: ExternalArticleDoc[] = []
+    for (const c of courses) {
+      const slug = c.slug?.current
+      const url = slug ? `https://www.sanity.io/learn/course/${slug}` : null
+      if (!c.title || !url) continue
+      const _id = existing.canonical.get(url)
+      docs.push({
+        _id,
+        _type: 'externalArticle',
+        unlisted: false,
+        source: 'sanity_learn',
+        title: c.title,
+        url,
+        summary: c.summary ?? undefined,
+        published: dateOnly(c.published ?? undefined),
+      })
+    }
+
+    return await writeDocs(docs, {deleteIds: existing.duplicates})
+  }, [client, userIds.learn, writeDocs])
+
+  const run = useCallback(
+    async (which: Source | 'all', opts?: {force?: boolean}) => {
+      setBusy(which)
+      setLog((l) => [
+        `Starting sync: ${which}${opts?.force ? ' (force)' : ''} (${new Date().toLocaleString()})`,
+        ...l,
+      ])
+      try {
+        let count = 0
+        if (which === 'planetscale' || which === 'all') {
+          const n = await syncPlanetScale(opts?.force)
+          count += n
+          setLog((l) => [`PlanetScale upserted: ${n}`, ...l])
+        }
+        if (which === 'sanity_guides' || which === 'all') {
+          const n = await syncSanityGuides(opts?.force)
+          count += n
+          setLog((l) => [`Sanity guides upserted: ${n}`, ...l])
+        }
+        if (which === 'sanity_learn' || which === 'all') {
+          const n = await syncSanityLearn(opts?.force)
+          count += n
+          setLog((l) => [`Sanity learn upserted: ${n}`, ...l])
+        }
+        setLog((l) => [`Done. Total upserted: ${count}`, ...l])
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        setLog((l) => [`Error: ${msg}`, ...l])
+      } finally {
+        setBusy(null)
+      }
+    },
+    [syncPlanetScale, syncSanityGuides, syncSanityLearn],
+  )
+
+  return (
+    <Container width={2} padding={4}>
+      <Stack space={4}>
+        <Heading size={3}>External Articles</Heading>
+        <Text muted>
+          Imports and upserts external articles into your dataset. Uses your
+          current Studio permissions for writes.
+        </Text>
+
+        <Card padding={3} radius={2} shadow={1} tone="transparent">
+          <Stack space={3}>
+            <Flex gap={2} wrap="wrap">
+              <Button
+                icon={RefreshIcon}
+                text="Sync all"
+                tone="primary"
+                disabled={Boolean(busy)}
+                onClick={() => run('all')}
+              />
+              <Button
+                text="Force sync all"
+                tone="critical"
+                disabled={Boolean(busy)}
+                onClick={() => run('all', {force: true})}
+              />
+              <Button
+                text="PlanetScale"
+                disabled={Boolean(busy)}
+                onClick={() => run('planetscale')}
+              />
+              <Button
+                text="Force PlanetScale"
+                tone="critical"
+                disabled={Boolean(busy)}
+                onClick={() => run('planetscale', {force: true})}
+              />
+              <Button
+                text="Sanity guides"
+                disabled={Boolean(busy)}
+                onClick={() => run('sanity_guides')}
+              />
+              <Button
+                text="Force guides"
+                tone="critical"
+                disabled={Boolean(busy)}
+                onClick={() => run('sanity_guides', {force: true})}
+              />
+              <Button
+                text="Sanity Learn"
+                disabled={Boolean(busy)}
+                onClick={() => run('sanity_learn')}
+              />
+              <Button
+                text="Force learn"
+                tone="critical"
+                disabled={Boolean(busy)}
+                onClick={() => run('sanity_learn', {force: true})}
+              />
+            </Flex>
+
+            <Box>
+              <Text size={1} muted>
+                PlanetScale author filter: <strong>{authorName}</strong>
+              </Text>
+            </Box>
+          </Stack>
+        </Card>
+
+        <Card padding={3} radius={2} shadow={1}>
+          <Stack space={2}>
+            <Heading size={1}>Log</Heading>
+            <Stack space={2}>
+              {log.length === 0 ? (
+                <Text muted size={1}>
+                  No runs yet.
+                </Text>
+              ) : (
+                log.slice(0, 30).map((line, i) => (
+                  <Text key={i} size={1}>
+                    {line}
+                  </Text>
+                ))
+              )}
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}
+
+export const externalArticlesTool = {
+  name: 'external-articles',
+  title: 'External articles',
+  component: ExternalArticlesTool,
+  icon: RefreshIcon,
+}
+


### PR DESCRIPTION
Adds an externalArticle document type, imports PlanetScale/Sanity items via a Studio tool, and renders them in the home timeline.

Made-with: Cursor